### PR TITLE
metricsToFOM - explanatory comments added, minor improvements, Fabio's new thresholding

### DIFF
--- a/code/metricToFOM.ipynb
+++ b/code/metricToFOM.ipynb
@@ -32,7 +32,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -54,7 +54,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -78,7 +78,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -88,7 +88,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -107,7 +107,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 12,
    "metadata": {
     "scrolled": true
    },
@@ -116,6 +116,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "Healpix slicer using NSIDE=16, approximate resolution 219.871130 arcminutes\n",
+      "Healpix slicer using NSIDE=16, approximate resolution 219.871130 arcminutes\n",
+      "Healpix slicer using NSIDE=16, approximate resolution 219.871130 arcminutes\n",
+      "Healpix slicer using NSIDE=16, approximate resolution 219.871130 arcminutes\n",
+      "Healpix slicer using NSIDE=16, approximate resolution 219.871130 arcminutes\n",
+      "Healpix slicer using NSIDE=16, approximate resolution 219.871130 arcminutes\n",
       "Healpix slicer using NSIDE=16, approximate resolution 219.871130 arcminutes\n",
       "Healpix slicer using NSIDE=16, approximate resolution 219.871130 arcminutes\n",
       "Healpix slicer using NSIDE=16, approximate resolution 219.871130 arcminutes\n",
@@ -267,12 +273,6 @@
       "Healpix slicer using NSIDE=16, approximate resolution 219.871130 arcminutes\n",
       "Healpix slicer using NSIDE=16, approximate resolution 219.871130 arcminutes\n",
       "Healpix slicer using NSIDE=16, approximate resolution 219.871130 arcminutes\n",
-      "Healpix slicer using NSIDE=16, approximate resolution 219.871130 arcminutes\n",
-      "Healpix slicer using NSIDE=16, approximate resolution 219.871130 arcminutes\n",
-      "Healpix slicer using NSIDE=16, approximate resolution 219.871130 arcminutes\n",
-      "Healpix slicer using NSIDE=16, approximate resolution 219.871130 arcminutes\n",
-      "Healpix slicer using NSIDE=16, approximate resolution 219.871130 arcminutes\n",
-      "Healpix slicer using NSIDE=16, approximate resolution 219.871130 arcminutes\n",
       "Healpix slicer using NSIDE=16, approximate resolution 219.871130 arcminutes\n"
      ]
     }
@@ -311,7 +311,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -348,15 +348,26 @@
     "            data[metric][runName]=np.array(data[metric][runName])[np.where(np.isfinite(data[metric][runName]))]\n",
     "\n",
     "            ### If the user specified lower and upper thresholds, only consider further those HEALPIX whose\n",
-    "            ### value for *this* metric lies between the thresholds. If no threshold given, consider all the \n",
-    "            ### HEALPIX for which this metric has been computed. \n",
+    "            ### value for *this* metric lies between the thresholds. The thresholds can be supplied either as \n",
+    "            ### a dictionary with one value per metric, or as a single scalar each for hi and lo over all\n",
+    "            ### the metrics. If no threshold was given, consider all the HEALPIX for which this metric has \n",
+    "            ### been computed. \n",
     "            if treshold_min !=None and treshold_max !=None :\n",
-    "                ID_fom=np.where((data[metric][runName]>treshold_min) & (data[metric][runName]<treshold_max))\n",
+    "                if isinstance(treshold_min,dict) and isinstance(treshold_max,dict):\n",
+    "                    ID_fom=np.where((data[metric][runName]>treshold_min[metric][runName]) & (data[metric][runName]<treshold_max[metric][runName]))\n",
+    "                else:\n",
+    "                    ID_fom=np.where((data[metric][runName]>treshold_min) & (data[metric][runName]<treshold_max))\n",
     "            else:\n",
     "                if treshold_min !=None:\n",
-    "                    ID_fom=np.where(data[metric][runName]>treshold_min)\n",
+    "                    if isinstance(treshold_min,dict):\n",
+    "                        ID_fom=np.where(data[metric][runName]>treshold_min[metric][runName])\n",
+    "                    else:\n",
+    "                        ID_fom=np.where(data[metric][runName]>treshold_min)\n",
     "                elif treshold_max !=None :\n",
-    "                    ID_fom=np.where(data[metric][runName]<treshold_max)\n",
+    "                    if isinstance(treshold_min,dict):\n",
+    "                        ID_fom=np.where(data[metric][runName]>treshold_max[metric][runName])\n",
+    "                    else:\n",
+    "                        ID_fom=np.where(data[metric][runName]>treshold_max)\n",
     "                else:\n",
     "                    ID_fom=np.repeat(True, len(data[metric][runName]))\n",
     "            \n",
@@ -487,7 +498,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
@@ -509,7 +520,7 @@
        "<Figure size 800x3000 with 1 Axes>"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }


### PR DESCRIPTION
I have made a few minor improvements to what was **metricsTo FOM**, including:

- Now outputs astropy Table with the spatially-summed FoMs for each run;
- Explanatory comments added throughout;
- Input directory and various other attributes (like the colormap) easier to set up-front;
- Fabio's latest rounds of improvements to **metricsTo FOM** have been included (improved handling of the thresholding and a bugfix in the way the **byfamily** option is handled (attribute **hlines** is not created if byfamily=False, so its addition to the axes now only happens if **byFamily** is **True**.

The new notebook **metricToFOM.ipynb** contains all these changes. The old notebook **metricTo FOM.ipynb** is still present.